### PR TITLE
Add FarmOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1063,6 +1063,7 @@ _"True sustainability is open." - [protontypes](https://protontypes.eu/)_<br> <b
 - [Food and Agriculture Organization Corporate Statistical Database](http://www.fao.org/faostat/en/#data) - Disseminates statistical data collected and maintained by the Food and Agriculture Organization.
 - [The Bread Code](https://github.com/hendricius/the-bread-code) - This repository is dedicated to becoming your bread manifesto with useful tricks and hacks.
 - [Growstuff](https://github.com/Growstuff/growstuff) - Open source and open data platform that can predict when your plantings will be ready to harvest.
+- [FarmOS](https://farmos.org/) - Open source web-based application for farm management, planning, and record keeping.
 
 
 ## Sustainable Investment


### PR DESCRIPTION
Hello Open Sustainable Technology!

I would like to propose the addition of [FarmOS](https://farmos.org/).

FarmOS is a web application for farm management, planning, and record keeping. The software provides standard platform for agricultural data collection and management. The FarmOS code is hosted on Github [https://github.com/farmOS/farmOS](https://github.com/farmOS/farmOS).