### PR TITLE
Add Public Lab

### DIFF
--- a/docs/community.md
+++ b/docs/community.md
@@ -47,3 +47,4 @@ __Outstanding open communities developing independent and free sustainable techn
 - [Tomorrow](https://github.com/tmrowco) - The climate impact of everything made accessible to everyone.
 - [Project Drawdown](https://drawdown.ecochallenge.org/) - Helping the world stop global warming by achieving Drawdown as quickly, safely, and equitably as possible.
 - [Appropedia](https://www.appropedia.org/OpenClimate) - A wiki designed to collaborate on solutions in the areas of sustainability, poverty alleviation, and development cooperation.
+- [Public Lab](https://publiclab.org/) - A community and a non-profit, democratizing science to address environmental issues that affect people.


### PR DESCRIPTION
[Public Lab](https://publiclab.org/) is a community and a non-profit, democratizing science to address environmental issues that affect people.

The organization contributes to community science and environmental justice initiatives and develops open technologies.

Public Lab's code is open source and hosted on [Github](https://github.com/publiclab).