### PR TITLE
add the FlexMeasures project

### DIFF
--- a/README.md
+++ b/README.md
@@ -493,6 +493,7 @@ _"True sustainability is open." - [protontypes](https://protontypes.eu/)_<br> <b
 - [emonpi](https://github.com/openenergymonitor/emonpi) - The OpenEnergyMonitor system has the capability to monitor electrical energy use / generation, temperature and humidity.
 - [EmonLib](https://github.com/openenergymonitor/EmonLib) - Arduino Energy Monitoring Library.
 - [Emoncms](https://github.com/emoncms/emoncms) - A powerful open source web application for processing, logging and visualizing energy, temperature and other environmental data.
+- [FlexMeasures](https://github.com/SeitaBV/flexmeasures) - A platform for building energy flexibility services with forecasting and scheduling, written in Python & offering a USEF-conform API.
 - [STM32 Energy Monitoring](https://github.com/openenergymonitor/STM32) - The following resources are a work in progress guide to using the STM32 platform for energy monitoring, being written as part of development work into the next generation of OpenEnergyMonitor hardware.
 
 


### PR DESCRIPTION
Adding the FlexMeasures platform, which allows energy service companies (ESCos) to add energy flexibility services to their stack.
FlexMeasures acts as a data science backend, where forecasting and optimized intra-day planning can be run and the results are available through an API. Some basic forecasting & scheduling algorithms are built-in, we'll soon make it possible to plugin custom ones.

Read more on http://flexmeasures.readthedocs.org

My Tweet: A platform for building #energyflexibility services with forecasting and scheduling, written in Python & offering an API inspired by @USEFsmartenergy.
