### PR TITLE
Add Energy Web origin for their EAC platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -543,7 +543,7 @@ __A curated list of open technology projects to sustain a stable climate, energy
 - [PowerSimData](https://github.com/Breakthrough-Energy/PowerSimData) - Is part of a Python software ecosystem developed by Breakthrough Energy Sciences to carry out power flow study in the U.S. electrical grid.
 - [Digital Twins Definition Language ontology for Energy Grid](https://github.com/Azure/opendigitaltwins-energygrid) - A global standard for energy grid assets management, power system operations modeling and physical energy commodity market.
 - [SIMONA](https://github.com/ie3-institute/simona) - Provides a simulation toolbox to run and implement large-scale agent-based electricity grid simulations with focus on distribution grids.
-
+ - [Energy Web Origin](https://github.com/energywebfoundation/origin) - A set of SDKs and backend services that provide a platform for the issuance, management and trading of documents called Energy Attribute Certificates (EACs), which guarantee that produced energy comes from a renewable source.
 
 ### Datasets on Energy Systems
 


### PR DESCRIPTION
For more background on the organization, see their [whitepaper](https://github.com/energywebfoundation/paper)

The project has contribution guidelines, and has a variety of contributors, however I can't tell if these contributors have affiliations with the partner organizations of the project or not.

> Your project should be structured and documented in such a way that it can be reused and extended by others.
Haven't tried setting it up locally, but the [docs](https://energy-web-foundation-origin.readthedocs-hosted.com/en/latest/) look nice.

As of 2020, project was being piloted with 1.3GW of electricity from renewable providers, see [here](https://medium.com/energy-web-insights/central-american-electricity-retailer-mercados-el%C3%A9ctricos-and-energy-web-complete-first-stage-of-a147541c8c44).