### PR TITLE
Add Open-Meteo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1061,6 +1061,7 @@ If you're looking for an entry point into domains like renewable energy, climate
 
 ### Meteorological Observation
 
+- [Open-Meteo](https://github.com/open-meteo/open-meteo) - Global weather API for non-commercial use with hourly weather forecast.
 - [stationaRy](https://github.com/rich-iannone/stationaRy) - Get hourly meteorological data from one of thousands of global stations.
 - [weathercan](https://github.com/ropensci/weathercan) - This package makes it easier to search for and download multiple months/years of historical weather data from the Environment and Climate Change Canada (ECCC) website.
 - [metR](https://github.com/eliocamp/metR) - Several functions and utilities that make R better for handling meteorological data in the tidy data paradigm.


### PR DESCRIPTION
Insert URLs to the project(s) here: 
- https://github.com/open-meteo/open-meteo
- https://open-meteo.com/en/docs

This is a follow up on #95.

Explain what this list is about and why it should be included here:

Open-Meteo is an open-source weather forecast API. Global and regional weather models offer 7 days forecasts in hourly resolution. With more than 40 weather variables, Open-Meteo covers everything for agriculture, house-automation, tourism, solar and wind energy forecasting. Additionally more than 60 years of historical weather data are available to explore patterns in climate change.

Open-Meteo is build on top of open-data and is using the most trusted weather data from national weather services. APIs are available for free for non-commercial use and can be used without an API key.


The community behind OpenSustain.tech offers free marketing and consulting for open source projects added to the list. If you are interested just tick here.

- [x]  Share the project on all available social media channels. ( Reddit, Twitter, Linkedin, HackerNews ). 
- [x]  Collaborative blog post about the project with publication on OpenSustain.tech and OpenSource.com. 
- [x]  Get Feedback on your project. 
- [x]  Guidance on further development strategies and funding for the project. 

[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](https://makeapullrequest.com)
