### PR TITLE
Update README.md - Link to PACTA repo has changed

### DIFF
--- a/README.md
+++ b/README.md
@@ -1606,7 +1606,7 @@ df.head()
 - [gfer](https://github.com/Yuanchao-Xu/gfer) - Designed for green finance and environmental risk research focused on data collecting and analyzing in green finance and environmental risk research and analysis.
 - [WikiRate](https://github.com/wikirate/wikirate) - Facilitates research and analysis on complex topics in collaboration with partners, to make ESG data open, comparable and useful for all.
 - [Equinox](https://github.com/open-risk/equinox) - Supports the holistic risk management of sustainable finance projects.
-- [PACTA](https://github.com/RMI-PACTA/PACTA_analysis) - Measuring the alignment of financial portfolios with climate scenarios.
+- [PACTA](https://github.com/RMI-PACTA/pactaverse) - Measuring the alignment of financial portfolios with climate scenarios.
 
 
 ### Knowledge Platforms


### PR DESCRIPTION
PACTA now lives in a new repo (https://github.com/RMI-PACTA/pactaverse) that covers all relevant steps of data preparation and analysis. The previously linked repository will be deprecated, see https://github.com/RMI-PACTA/PACTA_analysis/pull/644

**Insert URLs to the project(s) here:**      
[ Your URLs ]

**Explain what this list is about and why it should be included here:**     
[ Your Text ]
