### PR TITLE
Adding Low-Voltage Load Forecasting Datasets to Curated Lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -1734,7 +1734,7 @@ df.head()
 - [geospatial-data-catalogs](https://github.com/giswqs/geospatial-data-catalogs) - A list of open geospatial datasets available on AWS, Earth Engine, Planetary Computer, and STAC Index.
 - [Profit and emission database](https://docs.google.com/spreadsheets/d/19MQbZbrCu4HpAWe6NU92CioYQ7KE8FvD9vl-r9qSjJg/) - A free public database on large corporate emissions and profits.
 - [Industrial Ecology Dashboard](https://github.com/IndEcol/Dashboard) - A collection of open source projects relevant for industrial ecology practitioners.
-- [Low-Voltage Load Forecasting Datasets](https://github.com/low-voltage-loadforecasting/low-voltage-loadforecasting.github.io) - an overview of load forecasting datasets as presented in ["Review of low voltage load forecasting" paper](https://doi.org/10.1016/j.apenergy.2021.117798).
+- [Low-Voltage Load Forecasting Datasets](https://github.com/low-voltage-loadforecasting/low-voltage-loadforecasting.github.io) - An overview and review of load forecasting datasets.
 
 
 ## Contributors

--- a/README.md
+++ b/README.md
@@ -1734,6 +1734,7 @@ df.head()
 - [geospatial-data-catalogs](https://github.com/giswqs/geospatial-data-catalogs) - A list of open geospatial datasets available on AWS, Earth Engine, Planetary Computer, and STAC Index.
 - [Profit and emission database](https://docs.google.com/spreadsheets/d/19MQbZbrCu4HpAWe6NU92CioYQ7KE8FvD9vl-r9qSjJg/) - A free public database on large corporate emissions and profits.
 - [Industrial Ecology Dashboard](https://github.com/IndEcol/Dashboard) - A collection of open source projects relevant for industrial ecology practitioners.
+- [Low-Voltage Load Forecasting Datasets](https://github.com/low-voltage-loadforecasting/low-voltage-loadforecasting.github.io) - an overview of load forecasting datasets as presented in ["Review of low voltage load forecasting" paper](https://doi.org/10.1016/j.apenergy.2021.117798).
 
 
 ## Contributors


### PR DESCRIPTION
Hi! I was referred to this list, and since I couldn't find it on the list, I suggest adding it to the Curated Lists part. I am not affiliated.

**URLs to the project:**      
https://github.com/low-voltage-loadforecasting/low-voltage-loadforecasting.github.io

This list specifically addresses the Low-Voltage Load Forecasting field and seems to be a useful resource to keep updated with regard to available datasets. The maintainers welcome contributions of additional datasets which can be utilized in low-voltage load forecasting.
