### PR TITLE
Adding Green Metrics Tool and Eco-CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -625,6 +625,8 @@ df.head()
 
 ### Computation and Communication
 
+- [Eco-CI](https://github.com/green-coding-berlin/eco-ci-energy-estimation) - Estimating the energy consumption of CI / CD pipelines on Github and Gitlab
+- [Green Metrics Tool](https://github.com/green-coding-berlin/green-metrics-tool) - An open source suite to measure, display and compare software energy and CO2 consumption for containerized software. External power meters as well as RAPL and also ML-estimation models are supported.
 - [Scaphandre](https://github.com/hubblo-org/scaphandre) - An open source software agent to track energy consumption of ICT services from the servers.
 - [Tracarbon](https://github.com/fvaleye/tracarbon) - Tracarbon tracks your device's energy consumption and calculates your carbon emissions using your location.
 - [H2020 CATALYST](https://gitlab.com/project-catalyst) - Converting data centres in energy flexibility ecosystems.


### PR DESCRIPTION
Added two of our projects for energy measurement / estimation with detailed description directly in the PR.

Both tools are open source and help developers to wage the energy consumption of an application in different phases like installation, booting, runtime but also testing to get a better overview over the total cost of the application.

Hope you find them useful for the list :)

**Insert URLs to the project(s) here:**      
- https://github.com/green-coding-berlin/green-metrics-tool
- https://github.com/green-coding-berlin/eco-ci-energy-estimation

**Explain what this list is about and why it should be included here:**     
- An open source suite to measure, display and compare software energy and CO2 consumption for containerized software. External power meters as well as RAPL and also ML-estimation models are supported.
- Estimating the energy consumption of CI / CD pipelines on Github and Gitlab