### PR TITLE
Add physrisk

### DIFF
--- a/README.md
+++ b/README.md
@@ -1897,6 +1897,7 @@ energy system designs and analysis of interactions between technologies.
 - [Equinox](https://github.com/open-risk/equinox) - Supports the holistic risk management of sustainable finance projects.
 - [PACTA](https://github.com/RMI-PACTA/pactaverse) - Measuring the alignment of financial portfolios with climate scenarios.
 - [Dataland](https://github.com/d-fine/Dataland) - A decentralized ecosystem for raw ESG-data where market participants exchange ESG-data in a transparent way.
+- [physrisk](https://github.com/os-climate/physrisk) - Primarily designed to run 'bottom-up' calculations that model the impact of climate hazards on large numbers of individual assets including natural and operations.
 
 ### Knowledge Platforms
 


### PR DESCRIPTION
**Insert URLs to the project here:**      
https://github.com/os-climate/physrisk

**In one sentence, explain what the project is about:**   
Physrisk is primarily designed to run 'bottom-up' calculations that model the impact of climate hazards on large numbers of individual assets (including natural) and operations.

- [x] The projects is active, documented, open source licensed, shows usage from external parties and is directly targeting environmental sustainability. Find more details in the [Contribution Guide](https://opensustain.tech/contributing/).
