### PR TITLE
Add requirements to be listed to the PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,3 +3,5 @@
 
 **In one sentence, explain what the project is about:**   
 [ Your Text ]
+
+- [ ] The projects is active, documented, open source licensed, shows usage from external parties and is directly targeting environmental sustainability. Find more details in the [Contribution Guide](https://opensustain.tech/contributing/).


### PR DESCRIPTION
The PR template was changed so that the contribution guide link and a summary of the requirements is been visible to every new contributor. 
