### PR TITLE
Add nmecr

### DIFF
--- a/README.md
+++ b/README.md
@@ -585,6 +585,7 @@ energy system designs and analysis of interactions between technologies.
 - [predyce](https://gitlab.com/polito-edyce-prelude/predyce) - Is the natural evolution of the conventional Energy Performance Certification into real time optimization of building performance and comfort, by capturing the building's dynamic behaviour, and at the same time providing transparent feedback, through an intuitive interface.
 - [EUReCA](https://github.com/BETALAB-team/EUReCA) - Provides an efficient and reliable Urban Building Energy Modeling platform, entirely developed in Python, aiming at simulating and predicting cities and urban areas energy consumption.
 - [ebcpy](https://github.com/RWTH-EBC/ebcpy) - Provides generic functions and classes commonly used for the analysis and optimization of energy systems, buildings and indoor climate.
+- [nmecr](https://github.com/kW-Labs/nmecr) - Builds upon the energy efficiency community's past efforts to model complex and nuanced building energy use profiles.
 
 ### Mobility and Transportation
 


### PR DESCRIPTION
**Insert URLs to the project here:**      
https://github.com/kW-Labs/nmecr

**In one sentence, explain what the project is about:**   
Builds upon the energy efficiency community's past efforts to model complex and nuanced building energy use profiles.

- [x] The projects is active, documented, open source licensed, shows usage from external parties and is directly targeting environmental sustainability. Find more details in the [Contribution Guide](https://opensustain.tech/contributing/).
