### PR TITLE
Add climate-finance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1948,6 +1948,7 @@ energy system designs and analysis of interactions between technologies.
 - [PACTA](https://github.com/RMI-PACTA/pactaverse) - Measuring the alignment of financial portfolios with climate scenarios.
 - [Dataland](https://github.com/d-fine/Dataland) - A decentralized ecosystem for raw ESG-data where market participants exchange ESG-data in a transparent way.
 - [physrisk](https://github.com/os-climate/physrisk) - Primarily designed to run 'bottom-up' calculations that model the impact of climate hazards on large numbers of individual assets including natural and operations.
+- [climate-finance](https://github.com/ONEcampaign/climate-finance-package) - Is the python package to get, clean, and work with international public climate finance.
 
 ### Knowledge Platforms
 


### PR DESCRIPTION
**Insert URLs to the project here:**      
https://github.com/ONEcampaign/climate-finance-package

**In one sentence, explain what the project is about:**   
Is the python package to get, clean, and work with international public climate finance.

- [x] The projects is active, documented, open source licensed, shows usage from external parties and is directly targeting environmental sustainability. Find more details in the [Contribution Guide](https://opensustain.tech/contributing/).

I found some documention of this project and a really impressiv report that has been created with this open source data and tools:

Documentation:
https://datacommons.one.org/data/climate-finance-files
Report:
https://datacommons.one.org/climate-finance-files