### PR TITLE
Add Quartz Solar Forecast

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ The metadata of the listed projects and organizations are used in several studie
 - [OTSun](https://github.com/bielcardona/OTSun) - A python package that uses the Monte Carlo Forward Ray Tracing for the optical analysis of Solar Thermal Collectors and Solar Cells.
 - [pvOps](https://github.com/sandialabs/pvOps) - Contains a series of functions to facilitate fusion of text-based data with time series production data collected at photovoltaic sites.
 - [CSP.guru](https://github.com/repolicy/csp-guru) - An open-source database of concentrating solar power plants of the world for energy modellers and analysts.
+- [Quartz Solar Forecast](https://github.com/openclimatefix/Open-Source-Quartz-Solar-Forecast) - The aim of the project is to build an open source PV forecast that is free and easy to use.
 
 ### Wind Energy
 


### PR DESCRIPTION
**Insert URLs to the project here:**      
https://github.com/openclimatefix/Open-Source-Quartz-Solar-Forecast

**In one sentence, explain what the project is about:**   
The aim of the project is to build an open source PV forecast that is free and easy to use.

- [x] The projects is active, documented, open source licensed, shows usage from external parties and is directly targeting environmental sustainability. Find more details in the [Contribution Guide](https://opensustain.tech/contributing/).
