### PR TITLE
Add AirMonitor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1789,6 +1789,7 @@ energy system designs and analysis of interactions between technologies.
 - [RAQSAPI](https://github.com/USEPA/RAQSAPI) - Retrieve data from the United States Environmental Protection Agency's Air Quality Systems.
 - [qualR](https://github.com/ropensci/qualR) - Download of air pollutants and meteorological information from CETESB QUALAR System for São Paulo, and MonitorAr Program, for Rio de Janeiro.
 - [AirQo](https://github.com/airqo-platform/AirQo-api) - Develop hardware and software tools to help deliver Clean Air for All African Cities.
+- [AirMonitor](https://github.com/MazamaScience/AirMonitor) - Utilities for working with hourly air quality monitoring data with a focus on small particulates PM2.5.
 
 
 ### Water Supply


### PR DESCRIPTION
**Insert URLs to the project here:**      
https://github.com/MazamaScience/AirMonitor

**In one sentence, explain what the project is about:**   
Utilities for working with hourly air quality monitoring data with a focus on small particulates PM2.5.

- [x] The projects is active, documented, open source licensed, shows usage from external parties and is directly targeting environmental sustainability. Find more details in the [Contribution Guide](https://opensustain.tech/contributing/).

_All issues marked as 'Good First Issue' of the project listed on OpenSustain.tech will be visible on ClimateTriage.com. This is a great way to welcome new community members to your project._
