### PR TITLE
Add SSMSE

### DIFF
--- a/README.md
+++ b/README.md
@@ -1197,6 +1197,7 @@ energy system designs and analysis of interactions between technologies.
 - [planktonr](https://github.com/PlanktonTeam/planktonr) - R package that facilitates the download, analysis and visualisation of phytoplankton and zooplankton data.
 - [worrms](https://github.com/ropensci/worrms) - A R client for the World Register of Marine Species.
 - [FIMS](https://github.com/NOAA-FIMS/FIMS) - A software system designed and architected to support next-generation fisheries stock assessment, ecosystem, and socioeconomic modeling.
+- [SSMSE](https://github.com/nmfs-fish-tools/SSMSE) - R package for performing Management Strategy Evaluation using Stock Synthesis.
   
 ### Terrestrial Animals
 - [auk](https://github.com/CornellLabofOrnithology/auk) - eBird Data Extraction and Processing in R.


### PR DESCRIPTION
**Insert URLs to the project here:**      
https://github.com/nmfs-fish-tools/SSMSE

- [x] The projects is active, documented, open source licensed, shows usage from external parties and is directly targeting environmental sustainability. Find more details in the [Contribution Guide](https://opensustain.tech/contributing/).

_All issues labeled as 'Good First Issue' of the project listed on OpenSustain.tech will be visible on [ClimateTriage.com](https://climatetriage.com/). This is a great way to welcome new community members to your project._
