### PR TITLE
Add prommis

### DIFF
--- a/README.md
+++ b/README.md
@@ -882,6 +882,7 @@ energy system designs and analysis of interactions between technologies.
 - [OpenSpecy](https://github.com/wincowgerDEV/OpenSpecy-package) - Raman and (FT)IR spectral analysis tool for plastic particles and other environmental samples.
 - [waste_flow](https://github.com/xapple/waste_flow) - A python package for retrieving and analyzing data concerning the waste management of European countries.
 - [The Clothing Loop](https://github.com/the-clothing-loop/website) - An initiative that offers an easy way for people to swap clothes with others in their own neighborhood.
+- [prommis](https://github.com/prommis/prommis) - Process Optimization and Modeling for Minerals Sustainability.
 
 ## Biosphere
 


### PR DESCRIPTION
**Insert URLs to the project here:**      
https://github.com/prommis/prommis

- [x] The projects is active, documented, open source licensed, shows usage from external parties and is directly targeting environmental sustainability. Find more details in the [Contribution Guide](https://opensustain.tech/contributing/).

_All issues labeled as 'Good First Issue' of the project listed on OpenSustain.tech will be visible on [ClimateTriage.com](https://climatetriage.com/). This is a great way to welcome new community members to your project._

Took me a bit of time to understand what this project does but the sustainability reference is clear in the use-case: https://prommis.readthedocs.io/en/latest/tutorials/diafiltration.html#case-study-separation-of-lithium-from-cobalt-via-diafiltration