### PR TITLE
Add OpenCastKit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1429,6 +1429,7 @@ energy system designs and analysis of interactions between technologies.
 - [brightsky](https://github.com/jdemaeyer/brightsky) - A JSON API for Germany's meteorological service as part of their Open Data program.
 - [IEM](https://github.com/akrherz/iem) - A website that provides weather data and forecasts for Iowa and the world.
 - [IMPROVER](https://github.com/metoppv/improver) - A library of algorithms for meteorological post-processing and verification.
+- [OpenCastKit](https://github.com/HFAiLab/OpenCastKit) - Open-source solutions of global data-driven high-resolution weather forecasting.
 
 ### Radiative Transfer
 - [lowtran](https://github.com/space-physics/lowtran) - Atmospheric absorption extinction, scatter and irradiance model in Python and Matlab.


### PR DESCRIPTION
**Insert URLs to the project here:**      
https://github.com/HFAiLab/OpenCastKit

- [x] The projects is active, documented, open source licensed, shows usage from external parties and is directly targeting environmental sustainability. Find more details in the [Contribution Guide](https://opensustain.tech/contributing/).

_All issues labeled as 'Good First Issue' of the project listed on OpenSustain.tech will be visible on [ClimateTriage.com](https://climatetriage.com/). This is a great way to welcome new community members to your project._
