### PR TITLE
Add EUREC4A Intake catalogue

### DIFF
--- a/README.md
+++ b/README.md
@@ -1375,7 +1375,6 @@ energy system designs and analysis of interactions between technologies.
 - [CloudDrift](https://github.com/Cloud-Drift/clouddrift) - Accelerates the use of Lagrangian data for atmospheric, oceanic, and climate sciences.
 - [IPART](https://github.com/ihesp/IPART) - A Python package for automated Atmospheric River (AR) detection, axis finding and AR tracking from gridded Integrated Vapor Transport data.
 
-
 ### Atmospheric Chemistry and Aerosol
 - [GEOS-Chem](https://github.com/geoschem/geos-chem) - Advance understanding of human and natural influences on the environment through a comprehensive, state-of-the-science, readily accessible global model of atmospheric composition.
 - [gcpy](https://github.com/geoschem/gcpy) - A Python-based toolkit containing useful functions for working specifically with the GEOS-Chem model of atmospheric chemistry and composition.
@@ -1392,6 +1391,7 @@ energy system designs and analysis of interactions between technologies.
 - [py-smps](https://github.com/quant-aq/py-smps) - Python package for analyzing and visualizing size-resolved aerosol data from a variety of aerosol sizing instruments. 
 - [MONET](https://github.com/noaa-oar-arl/MONET) - An open-source project and Python package that aims to create a common platform for atmospheric composition data analysis for weather and air quality models.
 - [APCEMM](https://github.com/MIT-LAE/APCEMM) - Aims to assess the chemical and microphysical perturbations introduced by a conventional aircraft, equipped with gas turbine engines.
+- [EUREC4A Intake catalogue](https://github.com/eurec4a/eurec4a-intake) - Access to data from the EUREC4A field campaign, which aims to improve the understanding of the interplay between clouds, convection and circulation and their role in climate change.
 
 ### Meteorological Observation and Forecast
 - [windrose](https://github.com/python-windrose/windrose) - A graphic tool used by meteorologists to give a succinct view of how wind speed and direction are typically distributed at a particular location.


### PR DESCRIPTION
**Insert URLs to the project here:**      
https://github.com/eurec4a/eurec4a-intake

- [x] The projects is active, documented, open source licensed, shows usage from external parties and is directly targeting environmental sustainability. Find more details in the [Contribution Guide](https://opensustain.tech/contributing/).

_All issues labeled as 'Good First Issue' of the project listed on OpenSustain.tech will be visible on [ClimateTriage.com](https://climatetriage.com/). This is a great way to welcome new community members to your project._

https://eurec4a.eu/
**Note: License can only be found on Zenodo not on GitHub: https://zenodo.org/records/8422322**