### PR TITLE
Add Mangrove Atlas

### DIFF
--- a/README.md
+++ b/README.md
@@ -1037,6 +1037,7 @@ energy system designs and analysis of interactions between technologies.
 - [FORTLS](https://github.com/Molina-Valero/FORTLS) - Detect and segment individual tree from remotely sensed data.
 - [dplR](https://github.com/AndyBunn/dplR) - A package for R that performs tree-ring analyses such as detrending, chronology building, and crossdating.
 - [LandR](https://github.com/PredictiveEcology/LandR/) - These models simulate forest vegetation dynamics based on LANDIS-II, and incorporate fire and insect disturbance, as well as other important ecological processes.
+- [Mangrove Atlas](https://github.com/Vizzuality/mangrove-atlas) - An online platform that provides the remote sensing data and tools for monitoring mangroves necessary for this.
 
 ### Plants and Vegetation
 - [OpenPlantPathology](https://github.com/openplantpathology/OpenPlantPathology) - Open Plant Pathology is an initiative that supports and promotes the spread of all open, transparent and reproducible practices in the field of plant pathology.


### PR DESCRIPTION
**Insert URLs to the project here:**      
https://github.com/Vizzuality/mangrove-atlas

- [x] The projects is active, documented, open source licensed, shows usage from external parties and is directly targeting environmental sustainability. Find more details in the [Contribution Guide](https://opensustain.tech/contributing/).

_All issues labeled as 'Good First Issue' of the project listed on OpenSustain.tech will be visible on [ClimateTriage.com](https://climatetriage.com/). This is a great way to welcome new community members to your project._
