### PR TITLE
Add SDEverywhere

### DIFF
--- a/README.md
+++ b/README.md
@@ -1715,6 +1715,7 @@ energy system designs and analysis of interactions between technologies.
 - [rwlts](https://github.com/brazil-data-cube/rwlts) - Support governments in making decisions about the impact of human activities on the environment, planning the use of natural resources, conserving biodiversity and monitoring climate change.
 - [AI for Global Climate Cooperation](https://github.com/mila-iqia/climate-cooperation-competition) - Modeling global cooperation in the RICE-N Integrated Assessment Model.
 - [Future Technology Transformation](https://github.com/cpmodel/FTT_StandAlone) - Integrated assessment model with a realistic treatment of technology diffusion.
+- [SDEverywhere](https://github.com/climateinteractive/SDEverywhere) - The framework for system dynamics models created for the global climate simulator En-ROADS, the climate policy simulator C-ROADS and the Energy Policy Simulator.
 
 
 ## Natural Resources


### PR DESCRIPTION
**Insert URLs to the project here:**      
https://github.com/climateinteractive/SDEverywhere

- [x] The projects is active, documented, open source licensed, shows usage from external parties and is directly targeting environmental sustainability. Find more details in the [Contribution Guide](https://opensustain.tech/contributing/).

_All issues labeled as 'Good First Issue' of the project listed on OpenSustain.tech will be visible on [ClimateTriage.com](https://climatetriage.com/). This is a great way to welcome new community members to your project._

Note: This is a framework created for various climate simulator. The climate simulator repos are not public but all the websites are CC.

> [Climate Interactive](https://www.climateinteractive.org/) has been using SDEverywhere in production since 2019 for their popular simulation tools:
[En-ROADS](https://en-roads.climateinteractive.org/) — an online global climate simulator that allows users to explore the impact of policies on hundreds of factors like energy prices, temperature, air quality, and sea level rise
[C-ROADS](https://c-roads.climateinteractive.org/) — an online policy simulator (also available as a macOS or Windows desktop application) that helps people understand the long-term climate impacts of national and regional greenhouse gas emission reductions at the global level
[Energy Innovation](https://energyinnovation.org/) uses SDEverywhere to produce their [Energy Policy Simulator](https://energypolicy.solutions/).