### PR TITLE
Add helios

### DIFF
--- a/README.md
+++ b/README.md
@@ -1531,6 +1531,7 @@ energy system designs and analysis of interactions between technologies.
 - [PCMDI Metrics Package](https://github.com/PCMDI/pcmdi_metrics) - Open-source Python package for Systematic Evaluation of Climate and Earth System Models.
 - [swell](https://github.com/GEOS-ESM/swell) - Used to generate experiments using the JEDI data assimilation system and NASA's Goddard Earth Observing System (GEOS) numerical weather forecast mode.
 - [TSMP](https://github.com/HPSCTerrSys/TSMP) - An open source scale-consistent, highly modular, massively parallel regional Earth system model.
+- [helios](https://github.com/JGCRI/helios) - An R package to process heating and cooling degrees for the Global Change Analysis Model (GCAM) from various sources such as WRF and CMIP.
 
 ### Climate Data Standards 
 - [cf-conventions](https://github.com/cf-convention/cf-conventions) - The conventions for CF (Climate and Forecast) metadata are designed to promote the processing and sharing of files created with the NetCDF API.


### PR DESCRIPTION
**Insert URLs to the project here:**      
https://github.com/JGCRI/helios

- [x] The projects is active, documented, open source licensed, shows usage from external parties and is directly targeting environmental sustainability. Find more details in the [Contribution Guide](https://opensustain.tech/contributing/).

_All issues labeled as 'Good First Issue' of the project listed on OpenSustain.tech will be visible on [ClimateTriage.com](https://climatetriage.com/). This is a great way to welcome new community members to your project._
