### PR TITLE
Add HeatpumpMonitor.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -554,6 +554,7 @@ energy system designs and analysis of interactions between technologies.
 - [Better Thermostat](https://github.com/KartoffelToby/better_thermostat) - This custom component for Home Assistant will add crucial features to your climate-controlling Thermostatic Radiator Valves to save you the work of creating automations to make it smart.
 - [A Carbon Tool](https://github.com/arup-group/a-carbon-tool) - An open source web application that enables users to estimate embodied carbon equivalent content from Building Information Models.
 - [CarboLifeCalc](https://github.com/DavidVeld/CarboLifeCalc) - An embodied carbon calculator for the built environment.
+- [HeatpumpMonitor.org](https://github.com/openenergymonitor/heatpumpmonitor.org) - An open source initiative to share and compare heat pump performance data.
 
 ### Mobility and Transportation
 - [stplanr](https://github.com/ropensci/stplanr) - A package for sustainable transport planning with R.


### PR DESCRIPTION
**Insert URLs to the project here:**      
https://github.com/openenergymonitor/heatpumpmonitor.org

- [x] The projects is active, documented, open source licensed, shows usage from external parties and is directly targeting environmental sustainability. Find more details in the [Contribution Guide](https://opensustain.tech/contributing/).

_All issues labeled as 'Good First Issue' of the project listed on OpenSustain.tech will be visible on [ClimateTriage.com](https://climatetriage.com/). This is a great way to welcome new community members to your project._
