### PR TITLE
Add mastodon feed

### DIFF
--- a/.github/workflows/post_mastodon.yml
+++ b/.github/workflows/post_mastodon.yml
@@ -1,0 +1,26 @@
+name: Send URLs from Commit Message as Mastodon
+
+on:
+  push:
+    branches:
+      - main
+jobs:
+  toot:
+    runs-on: ubuntu-latest
+    if: "contains(github.event.head_commit.message, 'https')"
+    steps:
+      - name: Extract Line with URL as Toot
+        env:
+          default_hashtags: " #climate #sustainability"
+        run: |
+              echo -e "${{ github.event.head_commit.message }}" >> toot
+              toot_message="$(cat toot | grep -m 1 https*)"$default_hashtags
+              echo "toot_message=$toot_message" >> $GITHUB_ENV
+      
+      - name: Send toot to Mastodon
+        id: mastodon
+        uses: cbrgm/mastodon-github-action@v2
+        with:
+            access-token: ${{ secrets.MASTODON_ACCESS_TOKEN }} # access token
+            url: ${{ secrets.MASTODON_URL }} # https://example.social
+            message: ${{ env.toot_message }}


### PR DESCRIPTION
Allows us to create Mastodon posts from commit messages on the main branch. This will allow us to post any new projects added to OpenSustain.tech to Mastodon, providing the community with a feed of newly listed projects.
When the commit message contains *https*, the entire commit message will be posted. 

Relates to issue #55 