### PR TITLE
Add CMIP6 Cookbook

### DIFF
--- a/education.md
+++ b/education.md
@@ -65,6 +65,7 @@
 - [PyPRECIS](https://github.com/MetOffice/PyPRECIS) - A learning tool to faciliate processing of regional climate model output.
 - [CSDMS Ivy](https://github.com/csdms/ivy) - Course material on scientific software development for researchers in earth and planetary surface processes.
 - [Sketchbook Earth](https://github.com/ECMWFCode4Earth/sketchbook-earth) - A project aiming to illustrate the production of Climate Intelligence Reports, traditionally done with the ECMWF’s in-house developed tools.
+- [CMIP6 Cookbook](https://github.com/ProjectPythia/cmip6-cookbook) - This Project Pythia Cookbook covers examples of analysis of Google Cloud CMIP6 data using Pangeo tools.
 
 ## Earth Observation 
 - [Radiant MLHub Tutorials](https://github.com/radiantearth/mlhub-tutorials) - Tutorials to access Radiant MLHub Training Datasets.


### PR DESCRIPTION
**Insert URLs to the project here:**      
https://github.com/ProjectPythia/cmip6-cookbook

- [x] The projects is active, documented, open source licensed, shows usage from external parties and is directly targeting environmental sustainability. Find more details in the [Contribution Guide](https://opensustain.tech/contributing/).

_All issues labeled as 'Good First Issue' of the project listed on OpenSustain.tech will be visible on [ClimateTriage.com](https://climatetriage.com/). This is a great way to welcome new community members to your project._
