### PR TITLE
Add ClearWater-Riverine

### DIFF
--- a/README.md
+++ b/README.md
@@ -1356,6 +1356,7 @@ energy system designs and analysis of interactions between technologies.
 - [Centerline-Width](https://github.com/cyschneck/centerline-width) - A Python package to find the centerline and width of rivers based on the latitude and longitude of the right and left bank.
 - [fwapg](https://github.com/smnorris/fwapg) - Extends British Columbia's Freshwater Atlas with PostgreSQL/PostGIS.
 - [HSPsquared](https://github.com/respec/HSPsquared) - A Python port of the Hydrological Simulation Program - FORTRAN, which has been used worldwide for more than 40 years to support water resources planning and management.
+- [ClearWater-Riverine](https://github.com/EcohydrologyTeam/ClearWater-riverine) - A 2D water quality transporter model to calculate conservative advection and diffusion of constituents from an unstructured grid of flows.
 
 ### Ocean Circulation Models
 - [MOM6](https://github.com/NOAA-GFDL/MOM6) - A numerical representation of the ocean fluid with applications from the process scale to the planetary circulation scale.


### PR DESCRIPTION
**Insert URLs to the project here:** https://github.com/EcohydrologyTeam/ClearWater-riverine

- [x] The projects is active, documented, open source licensed, shows usage from external parties and is directly targeting environmental sustainability. Find more details in the [Contribution Guide](https://opensustain.tech/contributing/).

_All issues labeled as **Good First Issue** of the project listed on [OpenSustain.tech](https://opensustain.tech/) will be visible on [ClimateTriage.com](https://climatetriage.com/). This is a great way to welcome new community members to your project._

All projects listed will be posted on our [Mastodon channel](https://mastodon.social/@opensustaintech).

