### PR TITLE
Add GEOH2

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,7 @@
 - [SciGRID_gas](https://www.gas.scigrid.de/) - Methods to create an automated network model of the European gas transportation network.
 - [Vehicle with Fuel Cell Powertrain](https://github.com/mathworks/Fuel-Cell-Vehicle-Model-Simscape) - Fuel cell electric vehicle with battery model and cooling system.
 - [VirtualFCS](https://github.com/Virtual-FCS/VirtualFCS) - A Modelica library for hybrid hydrogen fuel cell and battery power systems.
+- [GEOH2](https://github.com/ClimateCompatibleGrowth/GeoH2) - Calculates the locational cost of green hydrogen production, storage, transport, and conversion to meet demand in a specified location.
 
 ## Energy Systems
 ### Energy System Modeling Frameworks


### PR DESCRIPTION
**Insert URLs to the project here:** https://github.com/ClimateCompatibleGrowth/GeoH2

- [x] The projects is active, documented, open source licensed, shows usage from external parties and is directly targeting environmental sustainability. Find more details in the [Contribution Guide](https://opensustain.tech/contributing/).

_All issues labeled as **Good First Issue** of the project listed on [OpenSustain.tech](https://opensustain.tech/) will be visible on [ClimateTriage.com](https://climatetriage.com/). This is a great way to welcome new community members to your project._

All projects listed will be posted on our [Mastodon channel](https://mastodon.social/@opensustaintech) 

