### PR TITLE
Add Home Energy Analysis Tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -612,6 +612,7 @@ energy system designs and analysis of interactions between technologies.
 - [GridWorks SpaceHeat SCADA](https://github.com/thegridelectric/gw-scada-spaceheat-python) - Intended for running a heat pump thermal storage space heating system in a house, and doing this transactively.
 - [ComStock](https://github.com/NREL/ComStock) - National scale modeling of the U.S. commercial building stock supported by U.S. DOE, LADWP, and others and maintained by NREL.
 - [HeatPro](https://github.com/CEA-Liten/HeatPro) - Finds its roots in the need of using representative heating load curve for the simulation and optimization of various District Heating Network (DHN) production plant.
+- [Home Energy Analysis Tool](https://github.com/codeforboston/home-energy-analysis-tool) - Provide an app that helps residential energy coaches or advocates, and some homeowners, estimate a home's heating requirements (heat load) and assess whether proposed heat pumps have sufficient heating capacity for the home.
 
 ### Mobility and Transportation
 - [stplanr](https://github.com/ropensci/stplanr) - A package for sustainable transport planning with R.


### PR DESCRIPTION
**Insert URLs to the project here:** https://github.com/codeforboston/home-energy-analysis-tool

- [x] The projects is active, documented, open source licensed, shows usage from external parties and is directly targeting environmental sustainability. Find more details in the [Contribution Guide](https://opensustain.tech/contributing/).

_All issues labeled as **Good First Issue** of the project listed on [OpenSustain.tech](https://opensustain.tech/) will be visible on [ClimateTriage.com](https://climatetriage.com/). This is a great way to welcome new community members to your project._

All new projects listed will be posted on our [Mastodon channel](https://mastodon.social/@opensustaintech). 

