### PR TITLE
Add GitHub's Green Software Directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -2472,6 +2472,7 @@ parameter values.
 - [Awesome ERDDAP](https://github.com/IrishMarineInstitute/awesome-erddap) - A curated list of awesome Environmental Research Division's Data Access Program (ERDDAP) projects and deployments.
 - [Awesome Large Weather Models](https://github.com/jaychempan/Awesome-LWMs) - A collection of articles on Large Weather Models (LWMs), to make it easier to find and learn.
 - [ingestr](https://github.com/geco-bern/ingestr/) - Provides functions to extract environmental point data from large global files or remote data servers and create time series at user-specified temporal resolution.
+- [GitHub's Green Software Directory](https://github.com/github/GreenSoftwareDirectory) - A simple and easy-to-use resource that all developers can use to adopt green software tools.
 
 
 ## Contributors


### PR DESCRIPTION
**Insert URLs to the project here:** https://github.com/github/GreenSoftwareDirectory

- [x] The projects is active, documented, open source licensed, shows usage from external parties and is directly targeting environmental sustainability. Find more details in the [Contribution Guide](https://opensustain.tech/contributing/).

_All issues labeled as **Good First Issue** of the project listed on [OpenSustain.tech](https://opensustain.tech/) will be visible on [ClimateTriage.com](https://climatetriage.com/). This is a great way to welcome new community members to your project._

All new projects listed will be posted on our [Mastodon channel](https://mastodon.social/@opensustaintech). 

