### PR TITLE
Add bbsBayes2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1046,6 +1046,7 @@ energy system designs and analysis of interactions between technologies.
 - [palmerpenguins](https://github.com/allisonhorst/palmerpenguins/) - The palmerpenguins data contains size measurements for three penguin species observed on three islands in the Palmer Archipelago, Antarctica.
 - [auk](https://github.com/CornellLabofOrnithology/auk) - eBird Data Extraction and Processing in R.
 - [motus](https://github.com/MotusWTS/motus) - An R package for processing automated radio telemetry data from Motus, an international collaborative research network that uses coordinated automated radio telemetry to facilitate research and education on the ecology and conservation of migratory animals.
+- [bbsBayes2](https://github.com/bbsBayes/bbsBayes2) - An R Package for Hierarchical Bayesian Analysis of North American Breeding Bird Survey Data.
 
 ### Bioacoustics and Acoustic Data Analysis
 - [vak](https://github.com/vocalpy/vak) - A neural network framework for animal acoustic communication and bioacoustics.


### PR DESCRIPTION
**Insert URLs to the project here:** https://github.com/bbsBayes/bbsBayes2

- [x] The projects is active, documented, open source licensed, shows usage from external parties and is directly targeting environmental sustainability. Find more details in the [Contribution Guide](https://opensustain.tech/contributing/).

_All issues labeled as **Good First Issue** of the project listed on [OpenSustain.tech](https://opensustain.tech/) will be visible on [ClimateTriage.com](https://climatetriage.com/). This is a great way to welcome new community members to your project._

All new projects listed will be posted on our [Mastodon channel](https://mastodon.social/@opensustaintech). 

