### PR TITLE
Add AirBase

### DIFF
--- a/README.md
+++ b/README.md
@@ -2101,6 +2101,7 @@ parameter values.
 - [AirMonitor](https://github.com/MazamaScience/AirMonitor) - Utilities for working with hourly air quality monitoring data with a focus on small particulates PM2.5.
 - [BEETHOVEN](https://github.com/NIEHS/beethoven) - Building an extensible, reproducible, test-driven, harmonised, open-source, versioned, ensemble model for air quality.
 - [CanAirIO](https://github.com/kike-canaries/canairio_firmware) - A citizen science project using mobile and static sensors to measure air quality with cell phones and low-cost technology.
+- [AirBase](https://github.com/JohnPaton/airbase) - An easy downloader for air quality data provided by the European Environment Agency.
 
 ### Water Supply and Quality 
 - [Stormwater-Management-Model](https://github.com/USEPA/Stormwater-Management-Model) - Used for single event or long-term (continuous) simulation of runoff quantity and quality from primarily urban areas.


### PR DESCRIPTION
**Insert URLs to the project here:** https://github.com/JohnPaton/airbase

- [x] The projects is active, documented, open source licensed, shows usage from external parties and is directly targeting environmental sustainability. Find more details in the [Contribution Guide](https://opensustain.tech/contributing/).

_All issues labeled as **Good First Issue** of the project listed on [OpenSustain.tech](https://opensustain.tech/) will be visible on [ClimateTriage.com](https://climatetriage.com/). This is a great way to welcome new community members to your project._

All new projects listed will be posted on our [Mastodon channel](https://mastodon.social/@opensustaintech). 

