### PR TITLE
Integrate umami for website tracking

### DIFF
--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -1,5 +1,10 @@
 {% extends "base.html" %}
 
+{% block extrahead %}
+  {{ super() }}
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="6c3cf2c8-549d-4add-b7dc-5f25fd17c90b"></script>
+{% endblock %}
+
 {% block announce %}
 <a href="https://opencollective.com/open-sustainable-technology">
   <div style="color:#009485">


### PR DESCRIPTION
As discussed with @Ly0n today i implemented umami analytics so we can track the traffic.

The stats are available at [https://cloud.umami.is/share/KodbbfnFP3svs8th/opensustain.tech](https://cloud.umami.is/share/KodbbfnFP3svs8th/opensustain.tech) (it is on my personal umami cloud profile).
