### PR TITLE
Add public analytics in navbar

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -27,6 +27,7 @@ nav:
   - Report: "https://report.opensustain.tech/"
   - Podcast: "https://ossforclimate.sustainoss.org/"
   - ClimateTriage: "https://climatetriage.com/"
+  - Analytics: "https://eu.umami.is/share/KodbbfnFP3svs8th/opensustain.tech"
 
 
 theme:


### PR DESCRIPTION
Adds the public analytics stats accessible in the navbar

Closes: #886