### PR TITLE
Add ECCO Hackweek 2024 Website

### DIFF
--- a/education.md
+++ b/education.md
@@ -128,6 +128,7 @@
 - [Analytical Groundwater Modeling](https://github.com/pythongroundwaterbook/analytic_gw_book) - Analytical Groundwater Modeling: Theory and Applications Using Python.
 - [Intro to Physical Oceanography](https://github.com/rabernat/intro_to_physical_oceanography) - Course materials for Introduction to Physical Oceanography.
 - [Coastal Dynamics Open Codebook](https://github.com/floriscalkoen/CoastalCodeBook) - Discusses the interrelation between physical wave, flow, and sediment transport phenomena and the resulting morphodynamics of a wide variety of coastal systems.
+- [ECCO Hackweek 2024 Website](https://github.com/ECCO-Hackweek/ecco-2024) - Explore NASA’s ECCO Ocean State Estimate, using Python, Julia, and cloud-based resources to work on oceanographic and climate data projects.
 
 
 ## Natural Resources 


### PR DESCRIPTION
**Insert URLs to the project here:** https://github.com/ECCO-Hackweek/ecco-2024

- [x] The projects is active, documented, open source licensed, shows usage from external parties and is directly targeting environmental sustainability. Find more details in the [Contribution Guide](https://opensustain.tech/contributing/).

_All issues labeled as **Good First Issue** of the project listed on [OpenSustain.tech](https://opensustain.tech/) will be visible on [ClimateTriage.com](https://climatetriage.com/). This is a great way to welcome new community members to your project._

All new projects listed will be posted on our [Mastodon channel](https://mastodon.social/@opensustaintech). 

