### PR TITLE
Integration of OpenClimate.fund content 

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,8 +1,12 @@
-**Insert URLs to the project here:** 
+**Insert URL to the project you want to be reviewed here:** 
 
-- [ ] The projects is active, documented, open source licensed, shows usage from external parties and is directly targeting environmental sustainability. Find more details in the [Contribution Guide](https://opensustain.tech/contributing/).
+- [ ] The project is active, documented, open source licensed, shows usage from external parties and is directly targeting environmental sustainability. Find more details in the [Contribution Guide](https://opensustain.tech/contributing/).
 
-_All issues labeled as **Good First Issue** of the project listed on [OpenSustain.tech](https://opensustain.tech/) will be visible on [ClimateTriage.com](https://climatetriage.com/). This is a great way to welcome new community members to your project._
+All listed projects on [OpenSustain.tech](https://opensustain.tech/) will be supported via multiple community services:
 
-All new projects listed will be posted on our [Mastodon channel](https://mastodon.social/@opensustaintech). 
+1. Issues labeled as **Good First Issue** will be visible on [ClimateTriage.com](https://climatetriage.com/). This is a great way to welcome new community members to your project.
+2. All new projects listed will be posted on our [Mastodon](https://mastodon.social/@opensustaintech) and [Bluesky](https://bsky.app/profile/opensustaintech.bsky.social) channel. 
+3. Listed project that provide donation option via Open Source Collective or GitHub Sponsors can by nominated via [OpenClimate.fund](https://openclimate.fund/). All project currently supported can be found [here](https://opensustain.tech/spreadsheet/).
+
+**Insert an project you want to nominate for a micro grant here:**  
 

--- a/.github/workflows/ecosystems_to_grist.py
+++ b/.github/workflows/ecosystems_to_grist.py
@@ -353,13 +353,15 @@ df_grist_funding_organization["description"] = df_grist_organization.loc[mask, "
 df_grist_funding_organization["website"] = df_grist_organization.loc[mask, "organization_namespace_url"]
 df_grist_funding_organization["category"] = df_grist_organization.loc[mask, "organization_category"]
 df_grist_funding_organization["funding_links"] = df_grist_organization.loc[mask, "organization_funding_links"]
-df_grist_funding_organization = df_grist_funding_organization[df_grist_funding['name'] != 'protontypes']
+df_grist_funding_organization = df_grist_funding_organization[df_grist_funding_organization['name'] != 'protontypes']
 
 # In the beginning, we only support github and opencollective to keep the overheating on our side low. 
 df_grist_funding_organization = df_grist_funding_organization[df_grist_funding_organization['funding_links'].str.contains('github|opencollective')]
 
 # Append organization on projects to only provide one list for the user
 df_grist_funding = df_grist_funding.append(df_grist_funding_organization)
+
+df_grist_funding = df_grist_funding.sample(frac = 1).reset_index(drop=True)
 
 def calculate_size_in_bytes(data):
     """

--- a/.github/workflows/update_grist.yml
+++ b/.github/workflows/update_grist.yml
@@ -3,7 +3,7 @@ name: Update Grist Spreedsheets with metadata from ecosyste.ms
 on:
   schedule:
     # Run at 00:00 UTC every Monday
-    - cron: '0 0 * * 1'
+    - cron: '0 0 * * *'
 
 #on:
 #  push:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,15 +22,17 @@ If you just want to give a hint about a missing project, send an email at [tobia
 ## Contribute to the List  
 * Create a fork of this project.
 * Add your project in the following format:              
- ``- [Project Name](Project URL) - A sentence that describes your project and what makes it different from others.``     
-* Describe in at least one sentence why you think the project meets the guidelines.    
+ ``- [Project Name](Project URL) - A sentence that describes your project and what makes it different from others.``        
 * If available, use the Git link to the central repository of your project. This makes it easier for developers and maintainers to review the project faster.    
 * Create a pull request and wait for the reaction of the maintainer. 
 
-Further details on how do `Pull Requests` can be found in the official GitHub [documentation](https://docs.github.com/en/free-pro-team@latest/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request).
+More details on how to do pull requests can be found in the official GitHub [documentation](https://docs.github.com/en/free-pro-team@latest/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request).
 
 ## The Project Does Not Yet Meet the Criteria, What Now?
 If your project doesn't meet the community, documentation, or usage criteria because it's in its early stages, don't hesitate to create a pull request. We will label the pull request "Under Observation" so that we can review it later. If you wish, we can use our social media channels to help you find contributing communities and users. 
+
+## Post new entries on social media
+To simply follow new project that have been reviewed successfully, the commit message of the merge will be posted on our [Mastodon](https://mastodon.social/@opensustaintech) and [Bluesky](https://bsky.app/profile/opensustaintech.bsky.social) channel. To trigger the posting via GitHub Action, the reviewer of the project needs to add a short sentence describing your project and the full URL of your repository to the description of the merge commit. 
 
 ## Join the Community
 We welcome developers, scientists, artists, writers, journalists, entrepreneurs, and citizens alike. Join our regular community calls to learn more about how you can make a difference through open source action on climate and sustainability.

--- a/docs/blog/openclimatefund.md
+++ b/docs/blog/openclimatefund.md
@@ -1,0 +1,37 @@
+# Lunching OpenClimate.fund
+
+__Tobias Augspurger__  [:fontawesome-brands-linkedin:](https://www.linkedin.com/in/tobias-augspurger/) · __Michael Scheiwiller__  [:fontawesome-brands-linkedin:](https://www.linkedin.com/in/michael-scheiwiller-72086a1a0/) · __Andrew Nesbitt__  [:fontawesome-brands-mastodon:](https://mastodon.social/@andrewnez) · __Richard Littauer__ [:fontawesome-brands-linkedin:](https://www.linkedin.com/in/richard-littauer-130026138/) · __Benjamin Nickolls__ [:fontawesome-brands-linkedin:](https://www.linkedin.com/in/benjamuk/) · :octicons-calendar-24: October 20, 2024 ·
+
+**Kickstarting Open Source Funding to Tackle Climate Change and Biodiversity Loss**
+
+We're launching **OpenClimate.fund**, a community-driven initiative to support open source projects that address climate change and biodiversity loss. These are among the most pressing challenges of our time, yet open source efforts in these areas remain alarmingly underfunded. While significant resources are being spent on areas such as artificial intelligence and security, the environmental sector is largely left empty-handed when it comes to open source solutions. It's time to change that.
+
+OpenClimate.fund aims to bridge this gap by funding an ecosystem built on transparency, trust, and collaboration to advance climate-friendly technologies and measurable environmental impact.
+
+## A Community-Driven Funding Approach 
+
+In our first funding round, we’re introducing a **“positive snowball system"** to empower the community and drive meaningful change. Here’s what you can do:
+
+1. **Identify a high impact project missing** in the [OpenSustain.tech](https://opensustain.tech/) directory.
+2. **Submit it through our review process** using the [Contributing Guide](https://opensustain.tech/contributing/), which outlines the steps for nominating impactful open source initiatives. 
+3. **Nominate another project** from the [directory](https://docs.getgrist.com/doc/gSscJkc5Rb1Rw45gh1o1Yc/p/5) to receive a 100€ gift and a heartfelt thank-you message.
+
+To minimize overhead, this initial round will focus on projects that have been active within the last four months and accept donations through the platforms Open Source Collective or GitHub Sponsors. Despite rigorous data mining with our partner **Ecosyste.ms**, only 84 eligible projects have been identified so far at the date of launch — underscoring the urgent need for this initiative. Our own experience has also shown us that donations in this area are so rare that many projects don't even bother to ask for them. If your project is already listed but not yet proposed, simply add donation information about your GitHub organisation or open source project and it will automatically be included for Round 1. 
+
+With a pilot fund of **10,000€**, we are aware that this can only be a drop in the ocean considering the 2,200+ projects on OpenSustain.tech. Our goal is to spark a broader conversation about building a sustainable ecosystem for open source solutions tackling global environmental challenges. 
+
+## Preparing for Round 2 
+
+We believe that investing in the right open source projects can create a **cascading effect**, amplifying impact and accelerating sustainable transformation. We can no longer rely on black-box knowledge creation, because the decisions we make today are so critical. That’s why this first funding round is just the beginning. 
+
+Our long-term plan is to build a network of organizations and individuals who share our commitment to building a fund that distributes resources transparently and equitably into climate change relevant open source projects. By applying open science principles on the distribution decision process we analyse where our investment creates the most global impact for the open source ecosystem. Instead of providing seed funding for new development, we want to provide a basic income for the open source projects that are proving to be the basic infrastructure for computing in this area. 
+
+Similar to our [first report](https://raw.githubusercontent.com/protontypes/open-source-in-environmental-sustainability/main/OpenSourceSustainabilityEcosystem_080423.pdf), we combine **quantitative methods** with **qualitative insights** to identify where funding can have the greatest effect. By using projects data like dependents, citations, downloads, [Development Distribution Score](https://report.opensustain.tech/chapters/development-distribution-score) or issue frequency, we aim to evaluate and maximize the impact of individual projects. By combining our data with interviews, gab analytics and urgency analytics for curtain topics identified as part of the [IPBES](https://www.ipbes.net/global-assessment) and [IPCC](https://www.ipcc.ch/) reports, we are releasing a detalied open science report how our distribution metric has been created. But this time we’re not stopping at analysis—we’re turning these insights into outcomes.
+
+Thanks to the support of **[Ecosyste.ms Funds](https://funds.ecosyste.ms/)** and [Open Source Collective](https://oscollective.org/), we will have the right technology partners to channel funds directly to all organisations, projects and their dependencies identified on OpenSustain.tech within Round 2 based on 100% open source software. But scaling this effort requires more than technology - it requires a collective effort. 
+
+## Join Us in Disrupting the Status Quo 
+
+Are you ready to harness the power of openness to combat the destruction of our natural world? Whether you’re an individual, an organization, or an investor, there’s a place for you in this movement. Together, we can ensure that open source innovation drives a sustainable future. 
+
+**Visit [OpenClimate.fund](https://openclimate.fund/) today** to learn more, nominate projects, spread the word with **#openclimatefund**, get in touch with Michael or Tobias and follow us on Mastodon.

--- a/docs/blog/openclimatefund.md
+++ b/docs/blog/openclimatefund.md
@@ -1,8 +1,9 @@
-# Lunching OpenClimate.fund
+# Empowering Community-Driven Funding with OpenClimate.fund
 
-__Tobias Augspurger__  [:fontawesome-brands-linkedin:](https://www.linkedin.com/in/tobias-augspurger/) · __Michael Scheiwiller__  [:fontawesome-brands-linkedin:](https://www.linkedin.com/in/michael-scheiwiller-72086a1a0/) · __Andrew Nesbitt__  [:fontawesome-brands-mastodon:](https://mastodon.social/@andrewnez) · __Richard Littauer__ [:fontawesome-brands-linkedin:](https://www.linkedin.com/in/richard-littauer-130026138/) · __Benjamin Nickolls__ [:fontawesome-brands-linkedin:](https://www.linkedin.com/in/benjamuk/) · :octicons-calendar-24: October 20, 2024 ·
+__Tobias Augspurger__  [:fontawesome-brands-linkedin:](https://www.linkedin.com/in/tobias-augspurger/) · __Michael Scheiwiller__  [:fontawesome-brands-linkedin:](https://www.linkedin.com/in/michael-scheiwiller-72086a1a0/) · __Andrew Nesbitt__  [:fontawesome-brands-mastodon:](https://mastodon.social/@andrewnez) · __Richard Littauer__ [:fontawesome-brands-linkedin:](https://www.linkedin.com/in/richard-littauer-130026138/) · __Benjamin Nickolls__ [:fontawesome-brands-linkedin:](https://www.linkedin.com/in/benjamuk/)  
+:octicons-calendar-24: October 20, 2024 ·
 
-**Kickstarting Open Source Funding to Tackle Climate Change and Biodiversity Loss**
+---
 
 We're launching **OpenClimate.fund**, a community-driven initiative to support open source projects that address climate change and biodiversity loss. These are among the most pressing challenges of our time, yet open source efforts in these areas remain alarmingly underfunded. While significant resources are being spent on areas such as artificial intelligence and security, the environmental sector is largely left empty-handed when it comes to open source solutions. It's time to change that.
 

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -1,16 +1,16 @@
 {% extends "base.html" %}
 
 {% block extrahead %}
-  {{ super() }}
-  {% if config.extra.analytics.production_url in config.site_url %}
-    <script defer src="https://cloud.umami.is/script.js" data-website-id="6c3cf2c8-549d-4add-b7dc-5f25fd17c90b"></script>
-  {% endif %}
+{{ super() }}
+{% if config.extra.analytics.production_url in config.site_url %}
+<script defer src="https://cloud.umami.is/script.js" data-website-id="6c3cf2c8-549d-4add-b7dc-5f25fd17c90b"></script>
+{% endif %}
 {% endblock %}
 
 {% block announce %}
-<a href="https://opencollective.com/open-sustainable-technology">
+<a href="https://openclimate.fund/">
   <div style="color:#009485">
-    <strong> Help us to sponsor <font color="#f77700">our next report</font> </strong>
+    <strong> Join the funding revolution on <font color="#f77700">OpenClimate.fund</font> </strong>
     <span class="twemoji seedling" style="color:#009485">
       {% include ".icons/fontawesome/solid/seedling.svg" %}
     </span>

--- a/docs/presentations.md
+++ b/docs/presentations.md
@@ -1,0 +1,16 @@
+# Presentations 
+
+Public presentations at various conferences and other events highlighting the key role of open source in environmental sustainability.
+
+- [Hacking Earth from Space with Open Source](https://www.youtube.com/watch?v=8NP2iTaWIoc) - Major League Hacking - 2024
+- [How are open source projects creating climate impact?](https://www.youtube.com/watch?v=6aEFLPXT6l8) - Community Panel hosted by Open Climate Fix - 2024
+- [Innovation für die Tonne? Nachhaltigkeit durch Open Source](https://www.youtube.com/watch?v=P9xa-qPPh58) - Science Slam - 2023
+- [Open Source in Environmental Sustainability](https://www.youtube.com/watch?v=AW1ZvjSwV0I) - State of Open Con - 2023
+- [Open Source in Environmental Sustainability](https://archive.fosdem.org/2023/schedule/event/sustainability/) - FOSDEM - 2023
+- [Huddle: The Untapped Potential of Open Source Culture in the Fight Against Climate Change](https://www.youtube.com/watch?v=_c9twDNB144) - Terrado Climate School - 2022
+- [Measuring the Open and Sustainable Technology World](https://www.youtube.com/watch?v=uTbj70jb2hU) - LF Energy Spring Summit - 2021
+
+
+
+
+

--- a/docs/presentations.md
+++ b/docs/presentations.md
@@ -1,3 +1,10 @@
+---
+hide:
+  - navigation
+  - toc
+  - footer
+---
+
 # Presentations 
 
 Public presentations at various conferences and other events highlighting the key role of open source in environmental sustainability.

--- a/docs/spreadsheet.md
+++ b/docs/spreadsheet.md
@@ -8,7 +8,7 @@ hide:
 <style> .md-main__inner.md-grid { margin-top: 0 !important; } .md-typeset h1, .md-content__button { display: none; } </style>
 
 <iframe
-  src="https://docs.getgrist.com/doc/gSscJkc5Rb1Rw45gh1o1Yc"
+  src="https://docs.getgrist.com/doc/gSscJkc5Rb1Rw45gh1o1Yc/p/5"
   class="iframestyle" 
   >
 </iframe>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -12,6 +12,7 @@ nav:
   - Contribute: contributing.md
   - Blog:
       2024:
+        - "Lunching OpenClimate.fund" : blog/openclimatefund.md
         - "Closing the Gap: Accelerating environmental Open Source" : blog/closing-the-gap.md
         - "Sustain Open Source, Sustain the Planet: A new conversation" : blog/sustain-open-source.md
       2023: 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -29,6 +29,7 @@ nav:
   - Report: "https://report.opensustain.tech/"
   - Podcast: "https://ossforclimate.sustainoss.org/"
   - ClimateTriage: "https://climatetriage.com/"
+  - OpenClimate.fund: "https://openclimate.fund/"
 
 
 theme:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -30,6 +30,7 @@ nav:
   - Podcast: "https://ossforclimate.sustainoss.org/"
   - ClimateTriage: "https://climatetriage.com/"
   - OpenClimate.fund: "https://openclimate.fund/"
+  - Presentations: "presentations.md"
 
 
 theme:


### PR DESCRIPTION
- Add OpenClimate.fund to PR template
- Random listing of funding options in Grist spreadsheet
- Update Grist data every day.
- Add OpenClimate.fund blog post 
- Add header for OpenClimate.fund
- Add all the presentation recorded in the last years to a separated section.
