### PR TITLE
Add Privacy Policy to Footer

### DIFF
--- a/docs/privacy-policy.md
+++ b/docs/privacy-policy.md
@@ -1,0 +1,40 @@
+# Open Sustainable Technology - Privacy Policy
+
+The Open Sustainable Technology Community takes your privacy seriously. To better protect your privacy we provide this privacy policy notice explaining the way your personal information is collected and used.
+
+
+## Collection of Routine Information
+
+This website tracks basic information about their visitors. This information includes, IP addresses, browser details, timestamps and referring pages. None of this information can personally identify specific visitors to this website. The information is tracked for routine administration and maintenance purposes.
+
+
+## Cookies
+
+This websites does not use cookies to store information about a visitor’s preferences and history.
+
+
+## Advertisement and Other Third Parties
+
+Even if this website itself does not display any advertising, other third parties may use cookies, scripts and/or web beacons to track visitors activities on this website in order to display advertisements and other useful information. Such tracking is done directly by the third parties through their own servers and is subject to their own privacy policies. This website has no access or control over these cookies, scripts and/or web beacons that may be used by third parties. Learn how to [opt out of Google’s cookie usage](http://www.google.com/privacy_ads.html).
+
+
+## Links to Third Party Websites
+
+We have included links on this website for your use and reference. We are not responsible for the privacy policies on these websites. You should be aware that the privacy policies of these websites may differ from our own.
+
+
+## Security
+
+The security of your personal information is important to us, but remember that no method of transmission over the Internet, or method of electronic storage, is 100% secure. While we strive to use commercially acceptable means to protect your personal information, we cannot guarantee its absolute security.
+
+
+## Changes To This Privacy Policy
+
+This Privacy Policy is effective as of 18.01.2025 and will remain in effect except with respect to any changes in its provisions in the future, which will be in effect immediately after being posted on this page.
+
+We reserve the right to update or change our Privacy Policy at any time and you should check this Privacy Policy periodically. If we make any material changes to this Privacy Policy, we will notify you either through the email address you have provided us, or by placing a prominent notice on our website.
+
+
+## Contact Information
+
+For any questions or concerns regarding the privacy policy, please send us an email to OpenSustaintech@gmail.com.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -32,6 +32,7 @@ nav:
   - ClimateTriage: "https://climatetriage.com/"
   - OpenClimate.fund: "https://openclimate.fund/"
 
+copyright: Copyright &copy; Open Sustainable Technology Contributors - <a href="https://opensustain.tech/privacy-policy/">       Read our Privacy Policy</a> 
 
 theme:
   name: 'material'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -32,7 +32,8 @@ nav:
   - ClimateTriage: "https://climatetriage.com/"
   - OpenClimate.fund: "https://openclimate.fund/"
 
-copyright: Copyright &copy; Open Sustainable Technology Contributors - <a href="https://opensustain.tech/privacy-policy/">       Read our Privacy Policy</a> 
+copyright:    <a href="https://creativecommons.org/licenses/by/4.0/" target="_blank" rel="noopener noreferrer">
+      Creative Commons Attribution 4.0 International License   </a>  -  <a href="https://opensustain.tech/privacy-policy/"> Read our Privacy Policy</a> 
 
 theme:
   name: 'material'


### PR DESCRIPTION
Refers to #1027 
Add Privacy Policy to footer, including a copyright notice" Copyright &copy; Open Sustainable Technology Contributors"

As we do not use cookies, we do not need an annoying cookie banner. 

![image](https://github.com/user-attachments/assets/6346d95d-74c3-4ef9-8257-c6980e6f3beb)

