### PR TITLE
add e3/resolve into ESM frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,6 +423,7 @@ energy system designs and analysis of interactions between technologies.
 - [Balmorel](https://github.com/balmorelcommunity/Balmorel) - A bottom-up partial equilibrium energy system model that has traditionally been applied to investigate decarbonisation pathways of sector-coupled energy systems, infrastructure, renewable fuel production and more.
 - [open-energy-modeling-benchmarks](https://github.com/jump-dev/open-energy-modeling-benchmarks) - The purpose of this repository is to collate a collection of benchmarks related to open energy modeling in JuMP.
 - [flixOpt](https://github.com/flixOpt/flixOpt) - Python-based optimization framework designed to tackle energy and material flow problems using mixed-integer linear programming (MILP) and provides a powerful platform for both dispatch and investment optimization challenges.
+- [resolve](https://github.com/e3-/resolve) - Resolve is a Python-based least-cost capacity expansion model that identifies optimal electricity supply portfolios through capacity expansion and production simulation modeling. 
 
 ### Energy Markets
 - [Grid Singularity Energy Exchange](https://github.com/gridsingularity/gsy-e) - An interface to download and deploy interconnected, grid-aware energy marketplaces.


### PR DESCRIPTION
[** https://github.com/e3-/resolve ** ]

- [X] The project is active, documented, open source licensed, shows usage from external parties and is directly targeting environmental sustainability. Find more details in the [Contribution Guide](https://opensustain.tech/contributing/).
