### PR TITLE
Replace GridCal with VeraGrid in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -599,7 +599,7 @@ energy system designs and analysis of interactions between technologies.
 - [RTS-GMLC](https://github.com/GridMod/RTS-GMLC) - Reliability Test System of the Grid Modernization Lab Consortium.
 - [OpenDSS](https://sourceforge.net/projects/electricdss/) - An electric power Distribution System Simulator for supporting distributed resource integration and grid modernization efforts.
 - [PowerDynamics.jl](https://github.com/JuliaEnergy/PowerDynamics.jl) - Provides all the tools you need to create a dynamic power grid model and analyze it.
-- [GridCal](https://github.com/SanPen/GridCal) - Aims to be a complete platform for power systems research and simulation.
+- [VeraGrid](https://github.com/SanPen/VeraGrid) - Aims to be a complete platform for power systems research and simulation.
 - [Backbone](https://gitlab.vtt.fi/backbone/backbone) - A generic energy network optimization tool written in GAMS.
 - [mosaik](https://gitlab.com/mosaik/mosaik) - A flexible Smart Grid co-simulation framework.
 - [SmartGridToolbox](https://gitlab.com/SmartGridToolbox/SmartGridToolbox) - Designed to provide an extensible and flexible starting point for developing a wide variety of smart grid simulations and other applications.


### PR DESCRIPTION
https://github.com/sanpen/veragrid (renamed from https://github.com/sanpen/gridcal)

The project is:

- [ ] Active
- [ ] Documented
- [ ] Licensed with an open source license
- [ ] Shows usage from external parties
- [ ] Directly targets environmental sustainability

Find more details in the [Contribution Guide](https://opensustain.tech/contributing/).

All listed projects on [OpenSustain.tech](https://opensustain.tech/) will be supported via multiple community services:

1. Issues labeled as **Good First Issue** will be visible on [ClimateTriage.com](https://climatetriage.com/). This is a great way to welcome new community members to your project.
2. All new projects listed will be posted on our [Mastodon](https://mastodon.social/@opensustaintech) and [Bluesky](https://bsky.app/profile/opensustaintech.bsky.social) channel. 

