### PR TITLE
link to GENeSYS-MOD.gms repo instead of entire GENeSYS-MOD GitHub org

### DIFF
--- a/README.md
+++ b/README.md
@@ -473,7 +473,7 @@ Your contribution is essential to [keep this initative alive](https://opencollec
 - [Frictionless Energy data](https://sentinel-energy.github.io/friendly_data/) - Common medium to facilitate the flow of data between energy and environmental models in a way that can be automated.
 - [Open Modeling Framework](https://github.com/dpinney/omf) - A set of Python libraries for simulating power systems behavior with an emphasis on cost-benefit analysis of emerging technologies.
 - [PSP-UFU](https://github.com/Thales1330/PSP) - Open-Source Software with advanced GUI features and CAD tools for electrical power system studies.
-- [GENeSYS-MOD](https://github.com/GENeSYS-MOD) - An open-source energy system model, originally based on the Open-Source Energy Modeling System (OSeMOSYS) framework, with various additions - available in GAMS and Julia/JuMP.
+- [GENeSYS-MOD](https://github.com/GENeSYS-MOD/GENeSYS_MOD.gms) - An open-source energy system model, originally based on the Open-Source Energy Modeling System (OSeMOSYS) framework, with various additions - available in GAMS and Julia/JuMP.
 - [PREP-SHOT](https://github.com/PREP-NexT/PREP-SHOT) - A transparent, modular, and open-source Energy Capacity Expansion Model.
 - [HYBRID](https://github.com/idaholab/HYBRID) - A modeling toolset to assess the integration and economic viability of Integrated Energy Systems.
 - [FAME](https://gitlab.com/fame-framework/fame-core) - Its purpose is supporting the rapid development and fast execution of complex agent-based energy system simulations.


### PR DESCRIPTION
as suggested by @andrew, this now links to the single repo instead of the overall GitHub org

relates to #1246

**Insert URL to the project you want to be reviewed here:** https://github.com/GENeSYS-MOD/GENeSYS_MOD.gms

The project is:

- [ ] Active
- [ ] Documented
- [ ] Licensed with an open source license
- [ ] Shows usage from external parties
- [ ] Directly targets environmental sustainability

Find more details in the [Contribution Guide](https://opensustain.tech/contributing/).

All listed projects on [OpenSustain.tech](https://opensustain.tech/) will be supported via multiple community services:

1. Issues labeled as **Good First Issue** will be visible on [ClimateTriage.com](https://climatetriage.com/). This is a great way to welcome new community members to your project.
2. All new projects listed will be posted on our [Mastodon](https://mastodon.social/@opensustaintech) and [Bluesky](https://bsky.app/profile/opensustaintech.bsky.social) channel. 

