### PR TITLE
Add ClimWeb

### DIFF
--- a/README.md
+++ b/README.md
@@ -2346,6 +2346,7 @@ parameter values.
 - [Breezy Weather](https://github.com/breezy-weather/breezy-weather) - A feature-rich weather app with good visualizations and more than 50 sources.
 - [MetObs-toolkit](https://github.com/vergauwenthomas/MetObs_toolkit) - Provides a comprehensive framework for scientists to process, quality control, and analyze raw meteorological data.
 - [Verif](https://github.com/WFRT/verif) - A command-line tool that lets you verify the quality of weather forecasts for point locations.
+- [ClimWeb](https://github.com/wmo-raf/climweb) - Wagtail based Open Source Content Management System for National Meteorological and Hydrological Services in Africa.
 
 ### Radiative Transfer
 


### PR DESCRIPTION
https://github.com/wmo-raf/climweb

The project is:

- [x] Active
- [x] Documented
- [x] Licensed with an open source license
- [x] Shows usage from external parties
- [x] Directly targets environmental sustainability

Find more details in the [Contribution Guide](https://opensustain.tech/contributing/).

All listed projects on [OpenSustain.tech](https://opensustain.tech/) will be supported via multiple community services:

1. Issues labeled as **Good First Issue** will be visible on [ClimateTriage.com](https://climatetriage.com/). This is a great way to welcome new community members to your project.
2. All new projects listed will be posted on our [Mastodon](https://mastodon.social/@opensustaintech) and [Bluesky](https://bsky.app/profile/opensustaintech.bsky.social) channel. 

