### PR TITLE
fix: remove runs of bluesky/mastodon post if last commit is from github actions

### DIFF
--- a/.github/workflows/post_mastodon_and_bluesky.yml
+++ b/.github/workflows/post_mastodon_and_bluesky.yml
@@ -6,6 +6,8 @@ on:
       - main
 jobs:
   toot:
+    # Preventing runs after changes made by Github actions
+    if: "!startsWith(github.event.head_commit.author.name, 'github-actions')"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code


### PR DESCRIPTION
This checks for the author of the last commit (making sure it's not a Github actions PR) before triggering a Bluesky and Mastodon post