### PR TITLE
fix: add linting in Github action for maintenance

### DIFF
--- a/.github/workflows/maintain_listing.yaml
+++ b/.github/workflows/maintain_listing.yaml
@@ -69,6 +69,9 @@ jobs:
           path: maintenance-diskcache/
           key: ${{ steps.cache-restore.outputs.cache-primary-key }}
 
+      # Run awesome lint (make sure to coordinate with "main.yml" action)
+      - run: npx awesome-lint@2.1.2
+
       - name: Defining Git identity 
         run: | 
           git config user.name github_actions


### PR DESCRIPTION
This makes sure that the Linting happens when the Github actions for listing maintenance happen as part of the actions sequence