### PR TITLE
Add pycmor

### DIFF
--- a/README.md
+++ b/README.md
@@ -2487,6 +2487,7 @@ parameter values.
 - [kerchunk](https://github.com/fsspec/kerchunk) - A library that provides a unified way to represent a variety of chunked, compressed data formats (e.g. NetCDF, HDF5, GRIB), allowing efficient access to the data from traditional file systems or cloud object storage.
 - [Zarr](https://github.com/zarr-developers/zarr-python) -  Provides an efficient, scalable, and flexible way to store and access large, multi-dimensional arrays, the core data format used in climate models and observational datasets.
 - [NCDatasets.jl](https://github.com/JuliaGeo/NCDatasets.jl) - Allows one to read and create netCDF files, with data sets and attribute lists behaving like Julia dictionaries and variables like Julia arrays, and it implements the CommonDataModel.jl interface.
+- [pycmor](https://github.com/esm-tools/pycmor) - A Python package to simplify the standardization of output into the Climate Model Output Rewriter standard.
 
 
 ### Climate Data Access and Visualization


### PR DESCRIPTION
https://github.com/esm-tools/pycmor

The project is:

- [x] Active
- [x] Documented
- [x] Licensed with an open source license
- [x] Shows usage from external parties
- [x] Directly targets environmental sustainability

Find more details in the [Contribution Guide](https://opensustain.tech/contributing/).

All listed projects on [OpenSustain.tech](https://opensustain.tech/) will be supported via multiple community services:

1. Issues labeled as **Good First Issue** will be visible on [ClimateTriage.com](https://climatetriage.com/). This is a great way to welcome new community members to your project.
2. All new projects listed will be posted on our [Mastodon](https://mastodon.social/@opensustaintech) and [Bluesky](https://bsky.app/profile/opensustaintech.bsky.social) channel. 

