### PR TITLE
docs: Add EcoCompute AI - Green FinOps for AI/ML Energy Optimization

### DIFF
--- a/README.md
+++ b/README.md
@@ -960,6 +960,7 @@ Your contribution is essential to [keep this initative alive](https://opencollec
 - [Principles of Green Software Engineering](https://github.com/jawache/principles-green) - Are a core set of competencies needed to define, build and run sustainable software applications.
 - [grid-intensity-go](https://github.com/thegreenwebfoundation/grid-intensity-go) - A tool written in go to help you factor carbon intensity into decisions about where and when to run computing jobs.
 - [Eco2AI](https://github.com/sb-ai-lab/Eco2AI) - A Python library which accumulates statistics about power consumption and CO2 emission during running code.
+- [EcoCompute AI](https://github.com/hongping-zh/ecocompute-ai) - A Green FinOps CI/CD gatekeeper that predicts PyTorch energy costs and carbon emissions before code merges, helping AI teams reduce GPU cloud spend.
 - [impact](https://github.com/mlco2/impact/) - Compute your ML model's emissions with our calculator and add the results to your paper with our generated LaTeX template.
 - [CodeCarbon](https://github.com/mlco2/codecarbon) - Track emissions from Compute and recommend ways to reduce their impact on the environment.
 - [experiment-impact-tracker](https://github.com/Breakend/experiment-impact-tracker) - Meant to be a simple drop-in method to track energy usage, carbon emissions, and compute utilization of your system.


### PR DESCRIPTION
Adding EcoCompute AI to the list - an open-source Green FinOps tool that helps AI teams predict and reduce GPU energy costs before code merges.

## Project Details

- **Name**: EcoCompute AI
- **Repository**: https://github.com/hongping-zh/ecocompute-ai
- **License**: Apache 2.0
- **Demo**: https://ecocompute-ai-d8zeusq2ti.edgeone.dev/

## Why it belongs here

EcoCompute AI directly addresses AI/ML sustainability by:
- Predicting energy costs of PyTorch/TensorFlow training runs
- Estimating carbon emissions (CO₂e) based on regional grid data
- Blocking expensive code in CI/CD pipelines before it runs
- Helping teams reduce GPU cloud spend by 30-50%

## Suggested Category

**Computation and Communication** or **Carbon Intensity and Accounting**
```- [EcoCompute AI](https://github.com/hongping-zh/ecocompute-ai) - Green FinOps CI/CD gatekeeper that predicts PyTorch energy costs and carbon emissions before code merges.
```