### PR TITLE
revert-pr-1464 Add POOPy

### DIFF
--- a/.github/workflows/post_mastodon_and_bluesky.yml
+++ b/.github/workflows/post_mastodon_and_bluesky.yml
@@ -21,7 +21,7 @@ jobs:
         run: |
               URL_git="$(git diff HEAD^ HEAD -- README.md | grep '^+' | grep -v '^+++' | grep -o 'https://[a-zA-Z0-9./?=_-]\+' || true)"
               echo $URL_git
-              URL_git_combine="$URL_git $default_message"
+              URL_git_combine=$default_message"$URL_git"
               echo "URL_git=$URL_git" >> $GITHUB_ENV
               echo "URL_git_combine=$URL_git_combine" >> $GITHUB_ENV
               if [ -z "$URL_git" ]; then

--- a/README.md
+++ b/README.md
@@ -2997,6 +2997,7 @@ Your contribution is essential to [keep this initative alive](https://opencollec
 - [tidywater](https://github.com/BrownandCaldwell-Public/tidywater) - Incorporates published water chemistry and empirical models in a standard format to build custom, comprehensive drinking water treatment processes.
 - [HydroPol2D](https://github.com/marcusnobrega-eng/HydroPol2D) - An open-source, high-resolution 2D model built in MATLAB for simulating overland flow, infiltration, groundwater-surface water interactions, and pollutant transport.
 - [EPyT-Control](https://github.com/WaterFutures/EPyT-Control) - A Python package for implementing and evaluating control algorithms & strategies in smart water networks.
+- [POOPy](https://github.com/AlexLipp/POOPy) - Object Oriented Python package for interfacing with English Water Companies Event Duration Monitoring data.
 - [Top Of The Poops](https://github.com/top-poop/top-of-the-poops) - Analysing Sewage Information from the UK Environment Agency.
 
 ### Soil and Land


### PR DESCRIPTION
https://github.com/AlexLipp/POOPy

The project is:

- [x] Active
- [x] Documented
- [x] Licensed with an open source license
- [x] Shows usage from external parties
- [x] Directly targets environmental sustainability

Find more details in the [Contribution Guide](https://opensustain.tech/contributing/).

All listed projects on [OpenSustain.tech](https://opensustain.tech/) will be supported via multiple community services:

1. Issues labeled as **Good First Issue** will be visible on [ClimateTriage.com](https://climatetriage.com/). This is a great way to welcome new community members to your project.
2. All new projects listed will be posted on our [Mastodon](https://mastodon.social/@opensustaintech) and [Bluesky](https://bsky.app/profile/opensustaintech.bsky.social) channel. 