### PR TITLE
Add GreenCalculus

### DIFF
--- a/README.md
+++ b/README.md
@@ -1195,6 +1195,7 @@ Your contribution is essential to [keep this initative alive](https://opencollec
 - [ddeq](https://gitlab.com/empa503/remote-sensing/ddeq) - A Python library for data-driven emission quantification of emission hot spots such as cities, power plants and industrial facilities.
 - [CPRG](https://github.com/Metropolitan-Council/ghg-cprg) - GHG Inventory using Climate Pollution Reduction Grant framework and funding.
 - [emit-ghg](https://github.com/emit-sds/emit-ghg) - Mapping of greenhouse gases with EMIT.
+- [GreenCalculus](https://github.com/greencalculus/greencalculus-calculator-demo) - Zero-dependency, GHG-Protocol-aligned carbon calculators (Scope 1/2/3, SBTi, PCAF, CBAM) from [greencalculus.com](https://greencalculus.com), each a single self-contained HTML file.
 
 
 ### Carbon Offsets and Trading 


### PR DESCRIPTION
Adds **GreenCalculus** under **Emissions → Carbon Intensity and Accounting**.

\- [GreenCalculus](https://github.com/greencalculus/greencalculus-calculator-demo) - Zero-dependency, GHG-Protocol-aligned carbon calculators (Scope 1/2/3, SBTi, PCAF, CBAM) from [greencalculus.com](https://greencalculus.com), each a single self-contained HTML file.

**How it meets the listing criteria**

- **Open source license:** MIT (`LICENSE` in the repo).
- **Central Git repository:** linked above; the demos are vanilla JS, single-file, no build step.
- **Active development:** last push June 2026; repo created May 2026 and updated regularly.
- **External use:** 8 stars and 7 forks from outside the core team.
- **Reusable & documented:** each calculator is one self-contained HTML file with a README gallery and a live-tool link, easy to fork, read, and extend.

**What makes it different:** rather than a single-purpose footprint tool, it covers the entire corporate GHG inventory (Scope 1, 2 and 3) plus target-setting and disclosure frameworks (SBTi, PCAF, CBAM) as zero-dependency, fully traceable demos aligned to the GHG Protocol and IPCC AR6.