### PR TITLE
Add GroundwaterCast to Freshwater and Hydrology

### DIFF
--- a/README.md
+++ b/README.md
@@ -2108,6 +2108,7 @@ Your contribution is essential to [keep this initative alive](https://opencollec
 - [HydroShare](https://github.com/hydroshare/hydroshare) - A collaborative website for better access to data and models in the hydrologic sciences.
 - [SOILWAT2](https://github.com/DrylandEcology/SOILWAT2) - An ecosystem water balance simulation model.
 - [RivGraph](https://github.com/VeinsOfTheEarth/RivGraph) - Extracting and quantifying graphical representations of river and delta channel networks from binary masks.
+- [GroundwaterCast](https://github.com/dominicm2023/groundwatercast-uk) - Daily probabilistic groundwater-level forecasts for every monitored borehole in England, built entirely on open data.
 - [WaterDetect](https://github.com/cordmaur/WaterDetect) - End-to-end algorithm to generate open water cover mask, specially conceived for L2A Sentinel 2 imagery from MAJA1 processor, without any a priori knowledge on the scene.
 - [FLAREr](https://github.com/FLARE-forecast/FLAREr) - Flexible, scalable, robust, and near-real time iterative ecological forecasts in lakes and reservoirs.
 - [Wflow](https://github.com/Deltares/Wflow.jl) - A Julia package that provides a hydrological modeling framework, as well as several different vertical and lateral concepts that can be used to run hydrological simulations.


### PR DESCRIPTION
Adds [GroundwaterCast](https://github.com/dominicm2023/groundwatercast-uk) to **Hydrosphere → Freshwater and Hydrology**.

**What it is:** an open-source (MIT) pipeline + site publishing daily probabilistic groundwater-level forecasts for every monitored borehole in England (~1,378 stations, 687 with full forecasts) — per-borehole calibrated [Pastas](https://github.com/pastas/pastas) transfer-function models driven by the 51-member ECMWF ensemble, with an experimental SEAS5-weighted seasonal outlook. Built entirely on openly-licensed data (EA hydrology OGL v3, ECMWF Open Data CC-BY-4.0, Copernicus ERA5/SEAS5), reproducible end-to-end, in daily operation at https://groundwatercast.com.

**Honest note on your criteria:** the project is in active daily operation and development, but it launched publicly only recently, so external-contributor signals (issues/PRs from others) are still thin. Happy to withdraw and return once there's clearer community uptake if you'd prefer — flagging it rather than have you discover it.