### PR TITLE
Add PV_ELM_pred and pv-dimensionality-reduction

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,8 @@ Your contribution is essential to [keep this initative alive](https://opencollec
 - [PVCracks](https://github.com/sandialabs/pvcracks) - Investigates the effects of cracks on power loss in photovoltaic (PV) solar cells and tracks crack progression over time.
 - [PASE](https://gitlab.uliege.be/deal-public/pase) - Simulate an agrivoltaic system, calculating both photovoltaic and agricultural output.
 - [PVNet](https://github.com/openclimatefix/PVNet) - A multi-modal late-fusion model for predicting renewable energy generation from weather data.
+- [PV_ELM_pred](https://github.com/cyrilvoyant/PV_ELM_pred) - Benchmarks persistence, cyclic blending, autoregressive and extreme learning machine models for photovoltaic power forecasting, scored against a persistence baseline on several sites.
+- [pv-dimensionality-reduction](https://github.com/cyrilvoyant/pv-dimensionality-reduction) - Forecasts photovoltaic power from the plant own past production alone, comparing seven dimensionality-reduction methods on an explicit accuracy versus model-size trade-off.
 
 ### Wind Energy
 


### PR DESCRIPTION
Two open-source benchmarks for short-term photovoltaic power forecasting, added to *Photovoltaics and Solar Energy*.

- **[PV_ELM_pred](https://github.com/cyrilvoyant/PV_ELM_pred)** - compares persistence, cyclic blending (BLEND), autoregressive OLS and a family of extreme learning machine variants on several PV sites, all scored against a persistence baseline. Complements PVNet and PVForecast already listed: those predict from weather inputs, this one quantifies how far you get from the production signal alone. [doi:10.5281/zenodo.21487267](https://doi.org/10.5281/zenodo.21487267)
- **[pv-dimensionality-reduction](https://github.com/cyrilvoyant/pv-dimensionality-reduction)** - treats endogenous PV forecasting as a geometric compression problem, comparing PCA, kernel PCA, Isomap, LLE, Laplacian eigenmaps, diffusion maps and an autoencoder with two independent diagnostics, and reporting every result against the model parameter count. The point is the accuracy-versus-footprint trade-off, which matters for embedded and low-power deployment. Published in *Sustainable Energy Technologies and Assessments* 83 (2025), [doi:10.1016/j.seta.2025.104588](https://doi.org/10.1016/j.seta.2025.104588)

Both are MIT-licensed, self-contained, documented, and ship with the datasets or the retrieval scripts needed to reproduce the published tables.

On the external-usage criterion: both are recent releases from an academic group and I cannot yet point to issues or PRs from outside users, so please feel free to apply the *Under Observation* label. I am a co-author of both.

Author: Cyril Voyant, Mines Paris - PSL, O.I.E. Laboratory - https://person.cyrilvoyant.com - Bluesky [@cyrilvoyant.bsky.social](https://bsky.app/profile/cyrilvoyant.bsky.social)