### PR TITLE
Add CommunityFix to Knowledge Platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -3325,6 +3325,7 @@ Your contribution is essential to [keep this initative alive](https://opencollec
 - [NRPTI](https://github.com/bcgov/NRPTI) - On this site you'll find records, documents and details of compliance and enforcement activities undertaken by British Columbia natural resource agencies such as administrative sanctions, administrative penalties, court convictions, inspections, orders, violation tickets and community environmental justice forums.
 - [QuotaClimat](https://github.com/dataforgoodfr/quotaclimat) - The aim of this work is to deliver a tool to a consortium around QuotaClimat, Climat Medias allowing them to quantify the media coverage of the climate crisis.
 - [Gold Mine Detector](https://github.com/earthrise-media/mining-detector) - Automated detection of artisanal gold mines in Sentinel-2 satellite imagery, with links to related journalism.
+- [CommunityFix](https://github.com/mathix420/communityfix) - An open knowledge platform where communities connect environmental and civic problems to proposed solutions and structured case studies with outcomes, costs, metrics, and sources.
 
 ### Data Catalogs and Interfaces
 


### PR DESCRIPTION
**Insert URL to the project you want to be reviewed here:** https://github.com/mathix420/communityfix

The project is:

- [x] Active
- [x] Documented
- [x] Licensed with an open source license
- [x] Shows usage from external parties
- [x] Directly targets environmental sustainability

CommunityFix is proposed for the Sustainable Development > Knowledge Platforms section. It structures environmental and civic problems, proposed solutions, and real-world case studies so communities can compare outcomes, costs, metrics, and sources.

Find more details in the [Contribution Guide](https://opensustain.tech/contributing/).

All listed projects on [OpenSustain.tech](https://opensustain.tech/) will be supported via multiple community services:

1. Issues labeled as **Good First Issue** will be visible on [ClimateTriage.com](https://climatetriage.com/). This is a great way to welcome new community members to your project.
2. All new projects listed will be posted on the OpenSustain.tech Mastodon and Bluesky channels.
